### PR TITLE
move flexcode from reqs.txt to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "pz-rail",
     "scikit-learn",
     "xgboost",
+    "FlexCode @ git+https://github.com/lee-group-cmu/FlexCode",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-FlexCode @ git+https://github.com/lee-group-cmu/FlexCode


### PR DESCRIPTION
pip install is not grabbing the requirements.txt requirement, now that we (i.e. Drew) noticed that we had the syntax wrong in the pyproject.toml that wasn't properly grabbing repos from GitHub rather than PyPI, we can now move the FlexCode requirement back to pyproject.toml.