### PR TITLE
move flexcode fork back to requirements.txt and add note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # rail_flexzboost
 RAIL interface to Flexzboost algorithms
 
-run command `pip install git+https://github.com/lee-group-cmu/FlexCode` to grab the forked version of FlexCode
+The older version of FlexCode that is currently available via PyPI/`pip install` has several old keywords included that cause the code to run more slowly.  For optimal performance you will need to get the updated fork of FlexCode available from the Lee CMU group.   Unfortunately, that is currently not on PyPI, and PyPI packaging does not allow automated install from a GitHub repo direct link.  For optimal performance, after you install `rail_flexzboost`  run the command
+```
+pip install git+https://github.com/lee-group-cmu/FlexCode
+```
+to grab the forked version of FlexCode.  We hope to eliminate this extra step in the near future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,7 @@ dynamic = ["version"]
 dependencies = [
     "pz-rail",
     "scikit-learn",
-    "xgboost",
-    "FlexCode @ git+https://github.com/lee-group-cmu/FlexCode",
+    "xgboost"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+FlexCode @ git+https://github.com/lee-group-cmu/FlexCode


### PR DESCRIPTION
move flex code to requirements.txt and add instructions telling users to just grab the forked flex code manually after install.  We can remove this once a forked version of the FlexCode repo is actually on PyPI