### PR TITLE
Adding notebook to compare storage requirements

### DIFF
--- a/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
+++ b/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
@@ -171,7 +171,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Example calculating median and mode."
+    "Example calculating median and mode. Note that we're using the `%%timeit` magic command to get an estimate of the time required for calculating `median`, but we're using `%%time` to estimate the `mode`. This is because `qp` will cache the output of the `pdf` function for a given grid. If we used `%%timeit`, then the resulting estimate would average the run time of one non-cached calculation and N-1 cached calculations. "
    ]
   },
   {
@@ -199,7 +199,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit\n",
+    "%%time\n",
     "fz_modes_qp_flexzboost = fzresults_qp_flexzboost().mode(grid=zgrid)"
    ]
   },
@@ -297,7 +297,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Example calculating median and mode."
+    "Example calculating median and mode. Note that we're using the `%%timeit` magic command to get an estimate of the time required for calculating `median`, but we're using `%%time` to estimate the `mode`. This is because `qp` will cache the output of the `pdf` function for a given grid. If we used `%%timeit`, then the resulting estimate would average the run time of one non-cached calculation and N-1 cached calculations."
    ]
   },
   {
@@ -325,7 +325,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit\n",
+    "%%time\n",
     "fz_modes_qp_interp = fzresults_qp_interp().mode(grid=zgrid)"
    ]
   },
@@ -382,24 +382,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# model_file_name = 'demo_FZB_model.pkl'\n",
-    "# flexzboost_file_name = './flexzboost.hdf5'\n",
-    "# interp_file_name = './interp.hdf5'\n",
+    "model_file_name = 'demo_FZB_model.pkl'\n",
+    "flexzboost_file_name = './flexzboost.hdf5'\n",
+    "interp_file_name = './interp.hdf5'\n",
     "\n",
-    "# try:\n",
-    "#     os.unlink(model_file_name)\n",
-    "# except FileNotFoundError:\n",
-    "#     pass\n",
+    "try:\n",
+    "    os.unlink(model_file_name)\n",
+    "except FileNotFoundError:\n",
+    "    pass\n",
     "\n",
-    "# try:\n",
-    "#     os.unlink(flexzboost_file_name)\n",
-    "# except FileNotFoundError:\n",
-    "#     pass\n",
+    "try:\n",
+    "    os.unlink(flexzboost_file_name)\n",
+    "except FileNotFoundError:\n",
+    "    pass\n",
     "\n",
-    "# try:\n",
-    "#     os.unlink(interp_file_name)\n",
-    "# except FileNotFoundError:\n",
-    "#     pass"
+    "try:\n",
+    "    os.unlink(interp_file_name)\n",
+    "except FileNotFoundError:\n",
+    "    pass"
    ]
   }
  ],

--- a/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
+++ b/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
@@ -15,6 +15,10 @@
    "outputs": [],
    "source": [
     "import os\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "import qp\n",
     "\n",
     "from rail.core.data import TableHandle\n",
     "from rail.core.stage import RailStage\n",
@@ -72,8 +76,7 @@
     "               nbump=20, sharpmin=0.7, sharpmax=2.1, nsharp=15,\n",
     "               max_basis=35, basis_system='cosine',\n",
     "               hdf5_groupname='photometry',\n",
-    "               regression_params={'max_depth': 8,'objective':'reg:squarederror'},\n",
-    "               storage_representation='parameterized')\n",
+    "               regression_params={'max_depth': 8,'objective':'reg:squarederror'})\n",
     "\n",
     "fz_modelfile = 'demo_FZB_model.pkl'"
    ]
@@ -168,6 +171,66 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Example calculating median and mode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "zgrid = np.linspace(0, 3., 301)\n",
+    "\n",
+    "fz_medians_qp_flexzboost = fzresults_qp_flexzboost().median()\n",
+    "fz_modes_qp_flexzboost = fzresults_qp_flexzboost().mode(grid=zgrid)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotting median values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "plt.hist(fz_medians_qp_flexzboost, bins=np.linspace(-.005,3.005,101));\n",
+    "plt.xlabel(\"redshift\")\n",
+    "plt.ylabel(\"Number\")\n",
+    "bins = np.linspace(-5, 5, 11)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example convertion to a `qp.hist` histogram representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "fzresults_qp_flexzboost().convert_to(qp.hist_gen, bins=bins)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "Now we'll repeat the experiment using `qp.interp` storage. Again, we'll define the RAIL stage to evaluate the test data using the saved model, but instruct `rail_flexzboost` to store the output as x,y interpolated values using `qp.interp`."
    ]
   },
@@ -209,6 +272,65 @@
     "fzresults_qp_interp = pzflex_qp_interp.estimate(test_data)\n",
     "file_size = os.path.getsize(output_file_name)\n",
     "print(\"File Size is :\", file_size, \"bytes\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example calculating median and mode."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "zgrid = np.linspace(0, 3., 301)\n",
+    "\n",
+    "fz_medians_qp_interp = fzresults_qp_interp().median()\n",
+    "fz_modes_qp_interp = fzresults_qp_interp().mode(grid=zgrid)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plotting median values."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "plt.hist(fz_medians_qp_interp, bins=np.linspace(-.005,3.005,101));\n",
+    "plt.xlabel(\"redshift\")\n",
+    "plt.ylabel(\"Number\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Example convertion to a `qp.hist` histogram representation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "fzresults_qp_interp().convert_to(qp.hist_gen, bins=bins)"
    ]
   },
   {

--- a/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
+++ b/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
@@ -132,9 +132,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "pzflex_qp_flexzboost = FZBoost.make_stage(name='fzboost', hdf5_groupname='photometry',\n",
+    "pzflex_qp_flexzboost = FZBoost.make_stage(name='fzboost_flexzboost', hdf5_groupname='photometry',\n",
     "                            model=inform_pzflex.get_handle('model'),\n",
+    "                            output='flexzboost.hdf5',\n",
     "                            qp_representation='flexzboost')"
    ]
   },
@@ -155,7 +155,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "output_file_name = './output_fzboost.hdf5'\n",
+    "output_file_name = './flexzboost.hdf5'\n",
     "try:\n",
     "    os.unlink(output_file_name)\n",
     "except FileNotFoundError:\n",
@@ -180,10 +180,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "zgrid = np.linspace(0, 3., 301)\n",
-    "\n",
-    "fz_medians_qp_flexzboost = fzresults_qp_flexzboost().median()\n",
+    "zgrid = np.linspace(0, 3., 301)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
+    "fz_medians_qp_flexzboost = fzresults_qp_flexzboost().median()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
     "fz_modes_qp_flexzboost = fzresults_qp_flexzboost().mode(grid=zgrid)"
    ]
   },
@@ -201,7 +217,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "fz_medians_qp_flexzboost = fzresults_qp_flexzboost().median()\n",
+    "\n",
     "plt.hist(fz_medians_qp_flexzboost, bins=np.linspace(-.005,3.005,101));\n",
     "plt.xlabel(\"redshift\")\n",
     "plt.ylabel(\"Number\")\n",
@@ -222,7 +239,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
+    "bins = np.linspace(-5, 5, 11)\n",
     "fzresults_qp_flexzboost().convert_to(qp.hist_gen, bins=bins)"
    ]
   },
@@ -240,9 +258,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "pzflex_qp_interp = FZBoost.make_stage(name='fzboost', hdf5_groupname='photometry',\n",
+    "pzflex_qp_interp = FZBoost.make_stage(name='fzboost_interp', hdf5_groupname='photometry',\n",
     "                            model=inform_pzflex.get_handle('model'),\n",
+    "                            output='interp.hdf5',\n",
     "                            qp_representation='interp')"
    ]
   },
@@ -263,7 +281,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "output_file_name = './output_fzboost.hdf5'\n",
+    "output_file_name = './interp.hdf5'\n",
     "try:\n",
     "    os.unlink(output_file_name)\n",
     "except FileNotFoundError:\n",
@@ -288,10 +306,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
-    "zgrid = np.linspace(0, 3., 301)\n",
-    "\n",
-    "fz_medians_qp_interp = fzresults_qp_interp().median()\n",
+    "zgrid = np.linspace(0, 3., 301)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
+    "fz_medians_qp_interp = fzresults_qp_interp().median()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%timeit\n",
     "fz_modes_qp_interp = fzresults_qp_interp().mode(grid=zgrid)"
    ]
   },
@@ -309,7 +343,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "fz_medians_qp_interp = fzresults_qp_interp().median()\n",
     "plt.hist(fz_medians_qp_interp, bins=np.linspace(-.005,3.005,101));\n",
     "plt.xlabel(\"redshift\")\n",
     "plt.ylabel(\"Number\")"
@@ -329,7 +363,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%time\n",
+    "%%timeit\n",
+    "bins = np.linspace(-5, 5, 11)\n",
     "fzresults_qp_interp().convert_to(qp.hist_gen, bins=bins)"
    ]
   },
@@ -347,18 +382,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_file_name = 'demo_FZB_model.pkl'\n",
-    "output_file_name = './output_fzboost.hdf5'\n",
+    "# model_file_name = 'demo_FZB_model.pkl'\n",
+    "# flexzboost_file_name = './flexzboost.hdf5'\n",
+    "# interp_file_name = './interp.hdf5'\n",
     "\n",
-    "try:\n",
-    "    os.unlink(model_file_name)\n",
-    "except FileNotFoundError:\n",
-    "    pass\n",
+    "# try:\n",
+    "#     os.unlink(model_file_name)\n",
+    "# except FileNotFoundError:\n",
+    "#     pass\n",
     "\n",
-    "try:\n",
-    "    os.unlink(output_file_name)\n",
-    "except FileNotFoundError:\n",
-    "    pass"
+    "# try:\n",
+    "#     os.unlink(flexzboost_file_name)\n",
+    "# except FileNotFoundError:\n",
+    "#     pass\n",
+    "\n",
+    "# try:\n",
+    "#     os.unlink(interp_file_name)\n",
+    "# except FileNotFoundError:\n",
+    "#     pass"
    ]
   }
  ],

--- a/docs/notebooks/fzboost_storage_comparison.ipynb
+++ b/docs/notebooks/fzboost_storage_comparison.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook does a quick comparison of storage requirements for Flexcode output using two different storage techniques. We'll compare `qp.interp` (x,y interpolated) output against the native parameterization of `qp_flexzboost`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "\n",
+    "from rail.core.data import TableHandle\n",
+    "from rail.core.stage import RailStage\n",
+    "\n",
+    "%matplotlib inline "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DS = RailStage.data_store\n",
+    "DS.__class__.allow_overwrite = True"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create references to the training and test data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rail.core.utils import RAILDIR\n",
+    "trainFile = os.path.join(RAILDIR, 'rail/examples/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = os.path.join(RAILDIR, 'rail/examples/testdata/test_dc2_validation_9816.hdf5')\n",
+    "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
+    "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the configurations for the ML model to be trained by Flexcode. Specifically we'll use Xgboost with a set of 35 cosine basis functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fz_dict = dict(zmin=0.0, zmax=3.0, nzbins=301,\n",
+    "               trainfrac=0.75, bumpmin=0.02, bumpmax=0.35,\n",
+    "               nbump=20, sharpmin=0.7, sharpmax=2.1, nsharp=15,\n",
+    "               max_basis=35, basis_system='cosine',\n",
+    "               hdf5_groupname='photometry',\n",
+    "               regression_params={'max_depth': 8,'objective':'reg:squarederror'},\n",
+    "               storage_representation='parameterized')\n",
+    "\n",
+    "fz_modelfile = 'demo_FZB_model.pkl'"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the RAIL stage to train the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rail.estimation.algos.flexzboost import Inform_FZBoost, FZBoost\n",
+    "inform_pzflex = Inform_FZBoost.make_stage(name='inform_fzboost', model=fz_modelfile, **fz_dict)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we'll run that stage to train the model and store the result in a file name `demo_FZB_model.pkl`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "inform_pzflex.inform(training_data)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we configure the RAIL stage that will evaluate test data using the saved model.\n",
+    "Note that we specify `qp_representation='flexzboost'` here to instruct `rail_flexzboost` to store the model weights using `qp_flexzboost`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pzflex_qp_flexzboost = FZBoost.make_stage(name='fzboost', hdf5_groupname='photometry',\n",
+    "                            model=inform_pzflex.get_handle('model'),\n",
+    "                            qp_representation='flexzboost')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we actually evaluate the test data, 20,449 example galaxies, using the trained model, and then print out the size of the file that was saved. \n",
+    "\n",
+    "Note that the final output size will depend on the number of basis functions used by the model. Again, for this experiment, we used 35 basis functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "output_file_name = './output_fzboost.hdf5'\n",
+    "try:\n",
+    "    os.unlink(output_file_name)\n",
+    "except FileNotFoundError:\n",
+    "    pass\n",
+    "\n",
+    "fzresults_qp_flexzboost = pzflex_qp_flexzboost.estimate(test_data)\n",
+    "file_size = os.path.getsize(output_file_name)\n",
+    "print(\"File Size is :\", file_size, \"bytes\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we'll repeat the experiment using `qp.interp` storage. Again, we'll define the RAIL stage to evaluate the test data using the saved model, but instruct `rail_flexzboost` to store the output as x,y interpolated values using `qp.interp`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "pzflex_qp_interp = FZBoost.make_stage(name='fzboost', hdf5_groupname='photometry',\n",
+    "                            model=inform_pzflex.get_handle('model'),\n",
+    "                            qp_representation='interp')"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally we evaluate the test data again using the trained model, and then print out the size of the file that was saved using the x,y interpolated technique.\n",
+    "\n",
+    "The final file size will depend on the size of the x grid that defines the interpolation. However, we can see that in order to match the storage requirements of `qp_flexzboost`, the x grid would need to be smaller than the number of basis functions used by the model. For this experiment, we used 35 basis functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "output_file_name = './output_fzboost.hdf5'\n",
+    "try:\n",
+    "    os.unlink(output_file_name)\n",
+    "except FileNotFoundError:\n",
+    "    pass\n",
+    "\n",
+    "fzresults_qp_interp = pzflex_qp_interp.estimate(test_data)\n",
+    "file_size = os.path.getsize(output_file_name)\n",
+    "print(\"File Size is :\", file_size, \"bytes\")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll clean up the files that were produced: the model pickle file, and the output data file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model_file_name = 'demo_FZB_model.pkl'\n",
+    "output_file_name = './output_fzboost.hdf5'\n",
+    "\n",
+    "try:\n",
+    "    os.unlink(model_file_name)\n",
+    "except FileNotFoundError:\n",
+    "    pass\n",
+    "\n",
+    "try:\n",
+    "    os.unlink(output_file_name)\n",
+    "except FileNotFoundError:\n",
+    "    pass"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "rail",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "47c0d775efeae3192041035019ca2d946443ef986557562adbc143cc5fa38455"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "coverage",
+    "ipykernel",
     "pylint",
     "pytest",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
 dev = [
     "coverage",
     "ipykernel",
+    "matplotlib",
+    "numpy",
     "pylint",
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
This notebook just shows the storage requirement differences between qp.interp and qp_flexzboost storage methods. The notebook also includes several cells that show the difference in computation time required for the two representations. Also added a dev dependency on ipykernel to pyproject.toml. 