### PR TITLE
Update paths in fzboost_pdf_representation_comparison.ipynb

### DIFF
--- a/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
+++ b/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
@@ -51,8 +51,8 @@
    "outputs": [],
    "source": [
     "from rail.core.utils import RAILDIR\n",
-    "trainFile = os.path.join(RAILDIR, 'rail/examples/testdata/test_dc2_training_9816.hdf5')\n",
-    "testFile = os.path.join(RAILDIR, 'rail/examples/testdata/test_dc2_validation_9816.hdf5')\n",
+    "trainFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_training_9816.hdf5')\n",
+    "testFile = os.path.join(RAILDIR, 'rail/examples_data/testdata/test_dc2_validation_9816.hdf5')\n",
     "training_data = DS.read_file(\"training_data\", TableHandle, trainFile)\n",
     "test_data = DS.read_file(\"test_data\", TableHandle, testFile)"
    ]


### PR DESCRIPTION
Updates to keep this package compatible with new directory names in pz-rail

_(Edit 4/25: new directory names are now live in pz-rail)_