### PR TITLE
add retrain_full config param to retrain with all training data

### DIFF
--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -55,6 +55,9 @@ class Inform_FZBoost(CatInformer):
                           err_bands=SHARED_PARAMS,
                           ref_band=SHARED_PARAMS,
                           redshift_col=SHARED_PARAMS,
+                          retrain_full=Param(bool, True, msg="if True, re-run the fit with the full training set, "
+                                             "including data set aside for bump/sharpen validation.  If False, only"
+                                             " use the subset defined via trainfrac fraction"),
                           trainfrac=Param(float, 0.75,
                                           msg="fraction of training "
                                           "data to use for training (rest used for bump thresh "
@@ -174,6 +177,15 @@ class Inform_FZBoost(CatInformer):
                 bestloss = tmploss
                 bestsharp = sharp
         model.sharpen_alpha = bestsharp
+
+        # retrain with full dataset or not
+        if self.config.retrain_full:
+            print("Retraining with full training set...")
+            model.fit(color_data, speczs)
+        else:  # pragma: no cover
+            print(f"Skipping retraining, only fraction {self.config.trainfrac}"
+                  "of training data used when training model")
+
         self.model = model
         self.add_data('model', self.model)
 


### PR DESCRIPTION
This PR adds a new config parameter that tells FZBoost to retrain the model with the full spec-z sample (the data is split into trainfrac and 1-trainfrac fractions to train an initial model and validation sample used to find the best bump_thresh and sharpen parameters).  I set the default value to True, as I think the generic user would expect all training data to be used when fitting the model.  if `retrain_full` is set to False it skips this retraining and the output model will only have been trained on a fraction `trainfrac` of the input data, which can save some time during testing.  Though, not as much as I thought, the simple notebook example in RAIL/examples/estimation_examples/ RAIL_estimation_demo.ipynb goes from 27s to 32s to train when turning off/on retrain_full.