### PR TITLE
naming consistency/clarity within src/rail/estimation

### DIFF
--- a/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
+++ b/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
@@ -95,8 +95,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from rail.estimation.algos.flexzboost import Inform_FZBoost, FZBoost\n",
-    "inform_pzflex = Inform_FZBoost.make_stage(name='inform_fzboost', model=fz_modelfile, **fz_dict)"
+    "from rail.estimation.algos.flexzboost import FlexZBoostInformer, FlexZBoostEstimator\n",
+    "inform_pzflex = FlexZBoostInformer.make_stage(name='inform_fzboost', model=fz_modelfile, **fz_dict)"
    ]
   },
   {
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pzflex_qp_flexzboost = FZBoost.make_stage(name='fzboost_flexzboost', hdf5_groupname='photometry',\n",
+    "pzflex_qp_flexzboost = FlexZBoostEstimator.make_stage(name='fzboost_flexzboost', hdf5_groupname='photometry',\n",
     "                            model=inform_pzflex.get_handle('model'),\n",
     "                            output='flexzboost.hdf5',\n",
     "                            qp_representation='flexzboost')"
@@ -258,7 +258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pzflex_qp_interp = FZBoost.make_stage(name='fzboost_interp', hdf5_groupname='photometry',\n",
+    "pzflex_qp_interp = FlexZBoostEstimator.make_stage(name='fzboost_interp', hdf5_groupname='photometry',\n",
     "                            model=inform_pzflex.get_handle('model'),\n",
     "                            output='interp.hdf5',\n",
     "                            qp_representation='interp')"

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -41,10 +41,10 @@ def make_color_data(data_dict, bands, err_bands, ref_band):
     return input_data.T
 
 
-class Inform_FZBoost(CatInformer):
-    """ Train a FZBoost CatEstimator
+class FlexZBoostInformer(CatInformer):
+    """ Train a FlexZBoost CatInformer
     """
-    name = 'Inform_FZBoost'
+    name = 'FlexZBoostInformer'
     config_options = CatInformer.config_options.copy()
     config_options.update(zmin=SHARED_PARAMS,
                           zmax=SHARED_PARAMS,
@@ -190,10 +190,10 @@ class Inform_FZBoost(CatInformer):
         self.add_data('model', self.model)
 
 
-class FZBoost(CatEstimator):
-    """FZBoost-based CatEstimator
+class FlexZBoostEstimator(CatEstimator):
+    """FlexZBoost-based CatEstimator
     """
-    name = 'FZBoost'
+    name = 'FlexZBoostEstimator'
     config_options = CatEstimator.config_options.copy()
     config_options.update(nzbins=SHARED_PARAMS,
                           nondetect_val=SHARED_PARAMS,

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -31,8 +31,8 @@ def test_flexzboost():
                          'model': 'model.tmp'}
     # zb_expected = np.array([0.13, 0.13, 0.13, 0.12, 0.12, 0.13, 0.12, 0.13,
     #                         0.12, 0.12])
-    train_algo = flexzboost.Inform_FZBoost
-    pz_algo = flexzboost.FZBoost
+    train_algo = flexzboost.FlexZBoostInformer
+    pz_algo = flexzboost.FlexZBoostEstimator
     results, rerun_results, rerun3_results = one_algo("FZBoost", train_algo, pz_algo, train_config_dict, estim_config_dict)
     # assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
@@ -54,8 +54,8 @@ def test_flexzboost_with_interp():
                          'qp_representation': 'interp'}
     # zb_expected = np.array([0.13, 0.13, 0.13, 0.12, 0.12, 0.13, 0.12, 0.13,
     #                         0.12, 0.12])
-    train_algo = flexzboost.Inform_FZBoost
-    pz_algo = flexzboost.FZBoost
+    train_algo = flexzboost.FlexZBoostInformer
+    pz_algo = flexzboost.FlexZBoostEstimator
     results, rerun_results, rerun3_results = one_algo("FZBoost", train_algo, pz_algo, train_config_dict, estim_config_dict)
     # assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
@@ -77,8 +77,8 @@ def test_flexzboost_with_qp_flexzboost():
                          'qp_representation': 'flexzboost'}
     # zb_expected = np.array([0.13, 0.13, 0.13, 0.12, 0.12, 0.13, 0.12, 0.13,
     #                         0.12, 0.12])
-    train_algo = flexzboost.Inform_FZBoost
-    pz_algo = flexzboost.FZBoost
+    train_algo = flexzboost.FlexZBoostInformer
+    pz_algo = flexzboost.FlexZBoostEstimator
     results, rerun_results, rerun3_results = one_algo("FZBoost", train_algo, pz_algo, train_config_dict, estim_config_dict)
     # assert np.isclose(results.ancil['zmode'], zb_expected).all()
     assert np.isclose(results.ancil['zmode'], rerun_results.ancil['zmode']).all()
@@ -101,8 +101,8 @@ def test_flexzboost_with_unknown_qp_representation():
                          'qp_representation': 'bogus'}
     # zb_expected = np.array([0.13, 0.13, 0.13, 0.12, 0.12, 0.13, 0.12, 0.13,
     #                         0.12, 0.12])
-    train_algo = flexzboost.Inform_FZBoost
-    pz_algo = flexzboost.FZBoost
+    train_algo = flexzboost.FlexZBoostInformer
+    pz_algo = flexzboost.FlexZBoostEstimator
     with pytest.raises(ValueError) as excinfo:
         one_algo("FZBoost", train_algo, pz_algo, train_config_dict, estim_config_dict)
         assert "Unknown qp_representation" in str(excinfo.value)
@@ -110,9 +110,9 @@ def test_flexzboost_with_unknown_qp_representation():
 def test_catch_bad_bands():
     params = dict(bands='u,g,r,i,z,y')
     with pytest.raises(ValueError):
-        flexzboost.Inform_FZBoost.make_stage(hdf5_groupname='', **params)
+        flexzboost.FlexZBoostInformer.make_stage(hdf5_groupname='', **params)
     with pytest.raises(ValueError):
-        flexzboost.FZBoost.make_stage(hdf5_groupname='', **params)
+        flexzboost.FlexZBoostEstimator.make_stage(hdf5_groupname='', **params)
 
 
 def test_missing_groupname_keyword():
@@ -126,7 +126,7 @@ def test_missing_groupname_keyword():
                                              'objective':
                                              'reg:squarederror'}}
     with pytest.raises(ValueError):
-        _ = flexzboost.FZBoost.make_stage(**config_dict)
+        _ = flexzboost.FlexZBoostEstimator.make_stage(**config_dict)
 
 
 def test_wrong_modelfile_keyword():
@@ -143,5 +143,5 @@ def test_wrong_modelfile_keyword():
                                              'reg:squarederror'},
                    'model': 'nonexist.pkl'}
     with pytest.raises(FileNotFoundError):
-        pz_algo = flexzboost.FZBoost.make_stage(**config_dict)
+        pz_algo = flexzboost.FlexZBoostEstimator.make_stage(**config_dict)
         assert pz_algo.model is None


### PR DESCRIPTION
## Change Description

This PR (and other concurrent PRs in the other repos) include renamings of modules and stages within `src/rail/estimation` for consistency and transparency to users as outlined in LSSTDESC/rail#37. (Expect a few more PRs to address the smaller set of necessary consistency/clarity changes outside `src/rail/estimation` using the same branch.) 

- [x] My PR includes a link to the issue that I am addressing

I request that multiple reviewers please do not hesitate to suggest changes as needed! The goals are consistency, clarity, and longevity, so if something looks unclear, inconsistent, or insufficiently flexible to accommodate future development, now is the time to make adjustments.

## Solution Description

The following changes were made across all the rail repos, along with updates to the contributing documentation (which should be propagated to the rail python project template so prompts regarding naming are included in future PR checklists).

```
files:
  delightPZ.py --> delight_hybrid.py
  GPz.py --> _gpz_util.py
  knnpz.py --> k_nearneigh.py
  naiveStack.py --> naive_stack.py
  NZDir.py --> nz_dir.py
  pointEstimateHist.py --> point_est_hist.py
  pzflow.py --> pzflow_nf.py
  randomPZ.py --> random_gauss.py
  simpleSOM.py --> minisom_som.py
  sklearn_nn.py --> skl_neurnet.py
  somocluSOM.py --> somoclu_som.py
  trainZ.py --> train_z.py
  varInference.py --> var_inf.py
classes:
  Inform_BPZ_lite --> BPZliteInformer
  BPZ_lite --> BPZliteEstimator
  Inform_CMNNPDF --> CMNNInformer
  CMNNPDF --> CMNNEstimator
  Inform_DelightPZ --> DelightInformer
  delightPZ --> DelightEstimator  
  Inform_GPz_v1 --> GPzInformer
  GPz_v1 --> GPzEstimator
  Inform_FZBoost --> FlexZBoostInformer
  FZBoost --> FlexZBoostEstimator
  Inform_KNearNeighPDF --> KNearNeighInformer
  KNearNeighPDF --> KNearNeighEstimator
  NaiveStack --> NaiveStackSummarizer
  NZDir --> NZDirSummarizer  
  Inform_NZDir --> NZDirInformer
  PointEstimateHist --> PointEstHistSummarizer
  Inform_PZFlowPDF --> PZFlowInformer
  PZFlowPDF --> PZFlowEstimator
  RandomPZ --> RandomGaussEstimator
  Inform_SimpleNN --> SklNeurNetInformer
  SimpleNN --> SklNeurNetEstimator
  Inform_SimpleSOMSummarizer --> MiniSOMInformer
  SimpleSOMSummarizer --> MiniSOMSummarizer
  Inform_somocluSOMSummarizer --> SOMocluInformer
  somocluSOMSummarizer --> SOMocluSummarizer
  Inform_trainZ --> TrainZInformer
  TrainZ --> TrainZEstimator
  VarInferenceStack --> VarInfStackSummarizer   
```

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [X] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

Given that we are still pre-v1, I have not explicitly included backward compatibility, but a block of `import X as Y` can be constructed from the above list of changes.

### Other Change Checklist
- [X] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have updated unit/End-to-End (E2E) test cases to cover any changes

I fixed some instances of outdated descriptions in the demo notebooks, but others require more substantial editing, e.g. when they describe code that has long since been removed from the demo in question or aspects of the API that have significantly changed since the descriptions were written. The demos require a thorough review before v1 that's out of scope for this series of PRs.