### PR TITLE
Respect the `calculated_point_estimates` config parameter 

### DIFF
--- a/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
+++ b/docs/notebooks/fzboost_pdf_representation_comparison.ipynb
@@ -132,7 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pzflex_qp_flexzboost = FZBoost.make_stage(name='fzboost_flexzboost', hdf5_groupname='photometry',\n",
+    "pzflex_qp_flexzboost = FZBoost.make_stage(name='fzboost_flexzboost',\n",
     "                            model=inform_pzflex.get_handle('model'),\n",
     "                            output='flexzboost.hdf5',\n",
     "                            qp_representation='flexzboost')"
@@ -189,7 +189,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%%timeit\n",
+    "%%time\n",
     "fz_medians_qp_flexzboost = fzresults_qp_flexzboost().median()"
    ]
   },
@@ -261,7 +261,8 @@
     "pzflex_qp_interp = FZBoost.make_stage(name='fzboost_interp', hdf5_groupname='photometry',\n",
     "                            model=inform_pzflex.get_handle('model'),\n",
     "                            output='interp.hdf5',\n",
-    "                            qp_representation='interp')"
+    "                            qp_representation='interp',\n",
+    "                            calculated_point_estimates=[])"
    ]
   },
   {
@@ -419,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.11.4"
   },
   "vscode": {
    "interpreter": {

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -240,19 +240,21 @@ class FlexZBoostEstimator(CatEstimator):
 
         ancil_dictionary = dict()
 
+        calculated_point_estimates = self.config.get('calculated_point_estimates', [])
+
         if self.config.qp_representation == 'interp':
             pdfs, z_grid = self.model.predict(color_data, n_grid=self.config.nzbins)
             self.zgrid = np.array(z_grid).flatten()
 
-            if 'mode' in self.config.calculated_point_estimates:
+            if 'mode' in calculated_point_estimates:
                 ancil_dictionary.update(mode = np.expand_dims(self.zgrid[np.argmax(pdfs, axis=1)], -1))
 
             qp_dstn = qp.Ensemble(qp.interp, data=dict(xvals=self.zgrid, yvals=pdfs))
 
-            if 'mean' in self.config.calculated_point_estimates:
+            if 'mean' in calculated_point_estimates:
                 ancil_dictionary.update(mean = qp_dstn.mean())
 
-            if 'median' in self.config.calculated_point_estimates:
+            if 'median' in calculated_point_estimates:
                 ancil_dictionary.update(median = qp_dstn.median())
 
         elif self.config.qp_representation == 'flexzboost':
@@ -261,17 +263,17 @@ class FlexZBoostEstimator(CatEstimator):
                                   data=dict(weights=basis_coefficients.coefs,
                                             basis_coefficients_object=basis_coefficients))
 
-            if 'mode' in self.config.calculated_point_estimates:
+            if 'mode' in calculated_point_estimates:
                 # `make_grid` is a helper function from Flexcode that will create a nested
                 # array of linearly spaced values. We then flatten that nested array.
                 # so the final output will have the form `[0.0, 0.1, ..., 3.0]`.
                 self.zgrid = np.array(make_grid(self.config.nzbins, basis_coefficients.z_min, basis_coefficients.z_max)).flatten()
                 ancil_dictionary.update(mode = qp_dstn.mode(grid=self.zgrid))
 
-            if 'mean' in self.config.calculated_point_estimates:
+            if 'mean' in calculated_point_estimates:
                 ancil_dictionary.update(mean = qp_dstn.mean())
 
-            if 'median' in self.config.calculated_point_estimates:
+            if 'median' in calculated_point_estimates:
                 ancil_dictionary.update(median = qp_dstn.median())
 
         else:

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -245,9 +245,15 @@ class FlexZBoostEstimator(CatEstimator):
             self.zgrid = np.array(z_grid).flatten()
 
             if 'mode' in self.config.calculated_point_estimates:
-                ancil_dictionary.update(zmode = np.expand_dims(self.zgrid[np.argmax(pdfs, axis=1)], -1))
+                ancil_dictionary.update(mode = np.expand_dims(self.zgrid[np.argmax(pdfs, axis=1)], -1))
 
             qp_dstn = qp.Ensemble(qp.interp, data=dict(xvals=self.zgrid, yvals=pdfs))
+
+            if 'mean' in self.config.calculated_point_estimates:
+                ancil_dictionary.update(mean = qp_dstn.mean())
+
+            if 'median' in self.config.calculated_point_estimates:
+                ancil_dictionary.update(median = qp_dstn.median())
 
         elif self.config.qp_representation == 'flexzboost':
             basis_coefficients = self.model.predict_coefs(color_data)
@@ -260,7 +266,13 @@ class FlexZBoostEstimator(CatEstimator):
                 # array of linearly spaced values. We then flatten that nested array.
                 # so the final output will have the form `[0.0, 0.1, ..., 3.0]`.
                 self.zgrid = np.array(make_grid(self.config.nzbins, basis_coefficients.z_min, basis_coefficients.z_max)).flatten()
-                ancil_dictionary.update(zmode = qp_dstn.mode(grid=self.zgrid))
+                ancil_dictionary.update(mode = qp_dstn.mode(grid=self.zgrid))
+
+            if 'mean' in self.config.calculated_point_estimates:
+                ancil_dictionary.update(mean = qp_dstn.mean())
+
+            if 'median' in self.config.calculated_point_estimates:
+                ancil_dictionary.update(median = qp_dstn.median())
 
         else:
             raise ValueError(f"Unknown qp_representation in config: {self.config.qp_representation}. Should be one of [interp|flexzboost]")

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -240,7 +240,9 @@ class FlexZBoostEstimator(CatEstimator):
 
         ancil_dictionary = dict()
 
-        calculated_point_estimates = self.config.get('calculated_point_estimates', [])
+        calculated_point_estimates = []
+        if 'calculated_point_estimates' in self.config:
+            calculated_point_estimates = self.config.calculated_point_estimates
 
         if self.config.qp_representation == 'interp':
             pdfs, z_grid = self.model.predict(color_data, n_grid=self.config.nzbins)

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -114,8 +114,9 @@ def test_catch_bad_bands():
     with pytest.raises(ValueError):
         flexzboost.FlexZBoostEstimator.make_stage(hdf5_groupname='', **params)
 
-
 def test_missing_groupname_keyword():
+    """hdf5_groupname will default to 'photometry'."""
+
     config_dict = {'zmin': 0.0, 'zmax': 3.0, 'nzbins': 301,
                    'trainfrac': 0.75, 'bumpmin': 0.02,
                    'bumpmax': 0.35, 'nbump': 3,
@@ -125,9 +126,8 @@ def test_missing_groupname_keyword():
                    'regression_params': {'max_depth': 8,
                                              'objective':
                                              'reg:squarederror'}}
-    with pytest.raises(ValueError):
-        _ = flexzboost.FlexZBoostEstimator.make_stage(**config_dict)
-
+    stage = flexzboost.FlexZBoostEstimator.make_stage(**config_dict)
+    assert stage.config_options['hdf5_groupname'] == "photometry"
 
 def test_wrong_modelfile_keyword():
     RailStage.data_store.clear()


### PR DESCRIPTION
## Work in progress

This PR represents the first `CatEstimator` subclass to use the `calculated_point_estimates` config parameter from `rail_base` to determine which point estimates (mode, mean, median) to calculate automatically and subsequently persist in the output hdf5 file.