### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "flexcode",
     "h5py",
     "pandas",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
     "qp-flexzboost",
     "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "flexcode",
     "h5py",
     "pandas",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "qp-prob[full]",
     "qp-flexzboost",
     "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "flexcode",
     "h5py",
     "pandas",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "qp-prob[full]",
     "qp-flexzboost",
     "scikit-learn",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "flexcode",
     "h5py",
     "pandas",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "qp-prob[full]",
     "qp-flexzboost",
     "scikit-learn",

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -84,7 +84,7 @@ class FlexZBoostInformer(CatInformer):
     def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization, then check on bands """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band not present in bands list! ")
 
@@ -207,7 +207,7 @@ class FlexZBoostEstimator(CatEstimator):
     def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatEstimator specific initialization """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band not present in bands list! ")
         self.zgrid = None

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -81,10 +81,10 @@ class FlexZBoostInformer(CatInformer):
                                                   "max_depth (int), and objective, which should be set "
                                                   " to reg:squarederror"))
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor
         Do CatInformer specific initialization, then check on bands """
-        CatInformer.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band not present in bands list! ")
 
@@ -204,10 +204,10 @@ class FlexZBoostEstimator(CatEstimator):
                           qp_representation=Param(str, "interp", msg="qp generator to use. [interp|flexzboost]")
                           )
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """ Constructor:
         Do CatEstimator specific initialization """
-        CatEstimator.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
         if self.config.ref_band not in self.config.bands:
             raise ValueError("ref_band not present in bands list! ")
         self.zgrid = None


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.