### PR TITLE
fix color errors

### DIFF
--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -37,7 +37,7 @@ def make_color_data(data_dict, bands, err_bands, ref_band):
         color = data_dict[bands[i]] - data_dict[bands[i + 1]]
         input_data = np.vstack((input_data, color))
         colorerr = np.sqrt(data_dict[err_bands[i]]**2 + data_dict[err_bands[i + 1]]**2)
-        np.vstack((input_data, colorerr))
+        input_data = np.vstack((input_data, colorerr))
     return input_data.T
 
 

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -116,18 +116,3 @@ def test_catch_bad_bands():
         flexzboost.FlexZBoostInformer.make_stage(hdf5_groupname='', **params)
     with pytest.raises(ValueError):
         flexzboost.FlexZBoostEstimator.make_stage(hdf5_groupname='', **params)
-
-def test_missing_groupname_keyword():
-    """hdf5_groupname will default to 'photometry'."""
-
-    config_dict = {'zmin': 0.0, 'zmax': 3.0, 'nzbins': 301,
-                   'trainfrac': 0.75, 'bumpmin': 0.02,
-                   'bumpmax': 0.35, 'nbump': 3,
-                   'sharpmin': 0.7, 'sharpmax': 2.1,
-                   'nsharp': 3, 'max_basis': 35,
-                   'basis_system': 'cosine',
-                   'regression_params': {'max_depth': 8,
-                                             'objective':
-                                             'reg:squarederror'}}
-    stage = flexzboost.FlexZBoostEstimator.make_stage(**config_dict)
-    assert stage.config_options['hdf5_groupname'] == "photometry"


### PR DESCRIPTION
## Problem & Solution Description (including issue #)

This PR fixes the bug described in Issue #44 by adding the color errors to the pre-processed array outputted by `make_color_data`


## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
