### PR TITLE
qp/updates_for_new_version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "h5py",
     "pandas",
     "pz-rail-base>=1.0.3",
-    "qp-prob>=1.0.0",
+    "qp-prob[full]>=1.0.0",
     "qp-flexzboost",
     "scikit-learn",
     "xgboost"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "h5py",
     "pandas",
     "pz-rail-base>=1.0.3",
-    "qp-prob[full]",
+    "qp-prob>=1.0.0",
     "qp-flexzboost",
     "scikit-learn",
     "xgboost"

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -261,9 +261,9 @@ class FlexZBoostEstimator(CatEstimator):
 
         elif self.config.qp_representation == 'flexzboost':
             basis_coefficients = self.model.predict_coefs(color_data)
-            qp_dstn = qp.Ensemble(qp_flexzboost.flexzboost_create_from_basis_coef_object,
+            qp_dstn = qp.Ensemble(qp_flexzboost.FlexzboostGen,
                                   data=dict(weights=basis_coefficients.coefs,
-                                            basis_coefficients_object=basis_coefficients))
+                                            basis_coefficients_object=basis_coefficients), method='basis_coef_object')
 
             if 'mode' in calculated_point_estimates:
                 # `make_grid` is a helper function from Flexcode that will create a nested


### PR DESCRIPTION
This contains updates for the new qp version (v.1.0.0) still under review.

## Code Quality
- [ ] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [ ] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
