### PR TITLE
add ability to use weights with training data

### DIFF
--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -186,7 +186,7 @@ class FlexZBoostInformer(CatInformer):
                 training_data = self.get_data("input")
             speczs = np.array(training_data[self.config["redshift_col"]])
             if self.config.use_weights:
-                if self.config.weights_column not in training_data.keys():
+                if self.config.weights_column not in training_data.keys():  # pragma: no cover
                     raise KeyError(f"column {self.config.weights_column} not in training_file")
                 train_weights = np.array(training_data[self.config.weights_column])
             else:
@@ -244,7 +244,8 @@ class FlexZBoostInformer(CatInformer):
                     )
             else:
                 train_dat, val_dat, train_sz, val_sz, train_w = self.split_data(
-                    color_data, speczs, self.config.trainfrac, self.config.seed
+                    color_data, speczs, self.config.trainfrac, self.config.seed,
+                    train_weights
                 )
                 print("read in training data")
                 print("fit the model...")

--- a/src/rail/estimation/algos/flexzboost.py
+++ b/src/rail/estimation/algos/flexzboost.py
@@ -116,6 +116,17 @@ class FlexZBoostInformer(CatInformer):
             False,
             msg="Include magnitude error in the training and estimation" "process",
         ),
+        use_weights=Param(
+            bool,
+            False,
+            msg="if True, will expect a column with name given by `weights_column` "
+            "config param in the input file to supply to the model fit"
+        ),
+        weights_column=Param(
+            str,
+            "None",
+            msg="name of weights column to be used if `use_weights` is True"
+        ),
     )
 
     def __init__(self, args, **kwargs):
@@ -126,7 +137,7 @@ class FlexZBoostInformer(CatInformer):
             raise ValueError("ref_band not present in bands list! ")
 
     @staticmethod
-    def split_data(fz_data, sz_data, trainfrac, seed):
+    def split_data(fz_data, sz_data, trainfrac, seed, weights=None):
         """
         make a random partition of the training data into training and
         validation, validation data will be used to determine bump
@@ -141,7 +152,11 @@ class FlexZBoostInformer(CatInformer):
         z_train = sz_data[perm[:ntrain]]
         x_val = fz_data[perm[ntrain:]]
         z_val = sz_data[perm[ntrain:]]
-        return x_train, x_val, z_train, z_val
+        if weights is not None:
+            w_train = weights[perm[:ntrain]]
+        else:
+            w_train = None
+        return x_train, x_val, z_train, z_val, w_train
 
     def divide_array(self, grid):
         if self.comm is None:
@@ -170,6 +185,12 @@ class FlexZBoostInformer(CatInformer):
             else:  # pragma: no cover
                 training_data = self.get_data("input")
             speczs = np.array(training_data[self.config["redshift_col"]])
+            if self.config.use_weights:
+                if self.config.weights_column not in training_data.keys():
+                    raise KeyError(f"column {self.config.weights_column} not in training_file")
+                train_weights = np.array(training_data[self.config.weights_column])
+            else:
+                train_weights = None
 
             # convert training data format to numpy dictionary
             if tables_io.types.table_type(training_data) != 1:
@@ -216,18 +237,18 @@ class FlexZBoostInformer(CatInformer):
                     )
                     model.bump_threshold = self.config.bumpmin
                     model.sharpen_alpha = self.config.sharpmin
-                    model.fit(color_data, speczs)
+                    model.fit(color_data, speczs, train_weights)
                 else:  # pragma: no cover
                     raise ValueError(
                         "trainfrac cannot be 1.0 when a grid search of bump and sharpen are performed, this leads to empty validation arrays!"
                     )
             else:
-                train_dat, val_dat, train_sz, val_sz = self.split_data(
+                train_dat, val_dat, train_sz, val_sz, train_w = self.split_data(
                     color_data, speczs, self.config.trainfrac, self.config.seed
                 )
                 print("read in training data")
                 print("fit the model...")
-                model.fit(train_dat, train_sz)
+                model.fit(train_dat, train_sz, train_w)
                 print("finding best bump thresh...")
         else:  # pragma: no cover
             model = None
@@ -290,7 +311,7 @@ class FlexZBoostInformer(CatInformer):
                 # retrain with full dataset or not
                 if self.config.retrain_full:
                     print("Retraining with full training set...")
-                    model.fit(color_data, speczs)
+                    model.fit(color_data, speczs, train_weights)
                 else:  # pragma: no cover
                     print(
                         f"Skipping retraining, only fraction {self.config.trainfrac}"

--- a/tests/test_algos.py
+++ b/tests/test_algos.py
@@ -3,8 +3,8 @@ import os
 import numpy as np
 import pytest
 import scipy.special
+import tables_io
 from rail.core.data import TableHandle
-from rail.core.stage import RailStage
 from rail.utils.path_utils import RAILDIR
 from rail.utils.testing_utils import one_algo
 
@@ -87,6 +87,54 @@ def test_flexzboost_with_interp():
     assert np.isclose(results.ancil["mode"], rerun_results.ancil["mode"]).all()
     assert np.isclose(results.ancil["mean"], rerun_results.ancil["mean"]).all()
     assert np.isclose(results.ancil["median"], rerun_results.ancil["median"]).all()
+
+
+def test_flexzboost_with_weights():
+    train_config_dict = {
+        "zmin": 0.0,
+        "zmax": 3.0,
+        "nzbins": 301,
+        "trainfrac": 0.75,
+        "bumpmin": 0.02,
+        "bumpmax": 0.35,
+        "nbump": 3,
+        "sharpmin": 0.7,
+        "sharpmax": 2.1,
+        "nsharp": 3,
+        "max_basis": 35,
+        "basis_system": "cosine",
+        "regression_params": {"max_depth": 8, "objective": "reg:squarederror"},
+        "hdf5_groupname": "photometry",
+        "model": "model.tmp",
+        "use_weights": True,
+        "weights_column": "weight"
+    }
+    estim_config_dict = {
+        "zmin": 0.0,
+        "zmax": 3.0,
+        "nzbins": 301,
+        "hdf5_groupname": "photometry",
+        "model": "model.tmp",
+        "qp_representation": "interp",
+        "calculated_point_estimates": ["mode", "mean"],
+    }
+    fakeweights = np.ones(100, dtype=float)
+    fakeweights[:25] *= 0.75
+    fakeweights[25:70] *= 0.9
+
+    traindata = os.path.join(RAILDIR, "rail/examples_data/testdata/training_100gal.hdf5")
+    validdata = os.path.join(RAILDIR, "rail/examples_data/testdata/validation_10gal.hdf5")
+    training_data = tables_io.read(traindata)
+    validation_data = tables_io.read(validdata)
+    training_data['photometry']['weight'] = fakeweights
+
+    train_pz = flexzboost.FlexZBoostInformer.make_stage(name="fzb_weight_train", **train_config_dict)
+    train_pz.inform(training_data)
+
+    pz = flexzboost.FlexZBoostEstimator.make_stage(name="fzb_weight_estim", **estim_config_dict)
+    results = pz.estimate(validation_data)
+
+    assert len(results().ancil["mode"]) == 10
 
 
 def test_flexzboost_skip_grid():
@@ -243,6 +291,6 @@ def test_pq_input_format():
     train_pz.inform(training_data)
 
     pz = pz_algo.make_stage(name="FZBoost", **estim_config_dict)
-    estim = pz.estimate(validation_data)
+    _ = pz.estimate(validation_data)
 
     os.remove(pz.get_output(pz.get_aliased_tag("output"), final_name=True))


### PR DESCRIPTION
Adds the ability to weight the training data via an optional `use_weights` config param, if `use_weights` is set to True then the code looks for a column specified by `weights_column` config param and uses that to weight the training data.  

## Code Quality
- [x] My code follows [the code style of this project](https://rail-hub.readthedocs.io/en/latest/source/contributing.html#naming-conventions)
- [x] I have written unit tests or justified all instances of `#pragma: no cover`; in the case of a bugfix, a new test that breaks as a result of the bug has been added
- [ ] My code contains relevant comments and necessary documentation for future maintainers; the change is reflected in applicable demos/tutorials (with output cleared!) and added/updated docstrings use the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] Any breaking changes, described above, are accompanied by backwards compatibility and deprecation warnings
